### PR TITLE
Add single instance enforcement and graceful shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,16 +3,50 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 )
 
 func main() {
 	fmt.Println("NFC UID Reader - Enhanced Version")
 	fmt.Println("==================================")
 
+	// Check for existing instances
+	singleInstance := NewSingleInstance("nfcuid")
+	globalSingleInstance = singleInstance  // Store globally for cleanup
+	
+	if !singleInstance.TryLock() {
+		// Check if another instance is actually running
+		isRunning, pid, err := singleInstance.GetRunningInstanceInfo()
+		if err != nil {
+			fmt.Printf("Error checking for existing instances: %v\n", err)
+			os.Exit(1)
+		}
+		
+		if isRunning {
+			fmt.Printf("Another instance of NFC UID Reader is already running (PID: %d)\n", pid)
+			fmt.Println("Please close the existing instance before starting a new one.")
+			fmt.Println("This prevents conflicts with keyboard input from multiple instances.")
+			os.Exit(1)
+		} else {
+			// Stale lock file was cleaned up, try again
+			if !singleInstance.TryLock() {
+				fmt.Println("Failed to acquire application lock after cleanup. Please try again.")
+				os.Exit(1)
+			}
+		}
+	}
+
+	// Setup cleanup on exit
+	setupGracefulShutdown(singleInstance)
+
+	fmt.Println("✓ Single instance lock acquired successfully")
+
 	// Load configuration
 	config, err := LoadConfig()
 	if err != nil {
 		fmt.Printf("Failed to load configuration: %v\n", err)
+		singleInstance.Release()
 		os.Exit(1)
 	}
 
@@ -48,4 +82,17 @@ func main() {
 	notificationManager.NotifyInfo("NFC Lesegerät", "Service gestartet - bereit zum Kartenlesen")
 	
 	service.Start()
+}
+
+// setupGracefulShutdown sets up signal handlers for graceful shutdown
+func setupGracefulShutdown(singleInstance *SingleInstance) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	
+	go func() {
+		<-c
+		fmt.Println("\nReceived shutdown signal, cleaning up...")
+		singleInstance.Release()
+		os.Exit(0)
+	}()
 }

--- a/main.go
+++ b/main.go
@@ -45,9 +45,7 @@ func main() {
 	// Load configuration
 	config, err := LoadConfig()
 	if err != nil {
-		fmt.Printf("Failed to load configuration: %v\n", err)
-		singleInstance.Release()
-		os.Exit(1)
+		SafeExit(1, fmt.Sprintf("Failed to load configuration: %v", err), nil)
 	}
 
 	// Initialize notification manager

--- a/singleinstance.go
+++ b/singleinstance.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+// SingleInstance provides functionality to prevent multiple instances of the application
+type SingleInstance struct {
+	lockFile *os.File
+	lockPath string
+}
+
+// NewSingleInstance creates a new SingleInstance manager
+func NewSingleInstance(appName string) *SingleInstance {
+	// Get appropriate temp directory based on OS
+	tempDir := os.TempDir()
+	lockPath := filepath.Join(tempDir, fmt.Sprintf("%s.lock", appName))
+	
+	return &SingleInstance{
+		lockPath: lockPath,
+	}
+}
+
+// TryLock attempts to acquire the lock to prevent multiple instances
+// Returns true if lock was acquired successfully, false if another instance is running
+func (si *SingleInstance) TryLock() bool {
+	// Try to open/create the lock file
+	file, err := os.OpenFile(si.lockPath, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0600)
+	if err != nil {
+		// If file already exists, check if the process is still running
+		if os.IsExist(err) {
+			return si.checkExistingInstance()
+		}
+		// Other error occurred
+		fmt.Printf("Warning: Failed to create lock file: %v\n", err)
+		return false
+	}
+
+	// Write current process ID to the lock file
+	pid := os.Getpid()
+	if _, err := file.WriteString(strconv.Itoa(pid)); err != nil {
+		file.Close()
+		os.Remove(si.lockPath)
+		fmt.Printf("Warning: Failed to write PID to lock file: %v\n", err)
+		return false
+	}
+
+	si.lockFile = file
+	return true
+}
+
+// checkExistingInstance checks if the process in the lock file is still running
+func (si *SingleInstance) checkExistingInstance() bool {
+	// Read the PID from the existing lock file
+	data, err := os.ReadFile(si.lockPath)
+	if err != nil {
+		// If we can't read the file, assume it's stale and try to remove it
+		os.Remove(si.lockPath)
+		return si.TryLock()
+	}
+
+	pidStr := string(data)
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		// Invalid PID in file, assume it's stale
+		os.Remove(si.lockPath)
+		return si.TryLock()
+	}
+
+	// Check if the process is still running
+	if !si.isProcessRunning(pid) {
+		// Process is not running, remove stale lock file
+		os.Remove(si.lockPath)
+		return si.TryLock()
+	}
+
+	// Process is still running, another instance exists
+	return false
+}
+
+// isProcessRunning checks if a process with the given PID is running
+func (si *SingleInstance) isProcessRunning(pid int) bool {
+	// Try to find the process
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+
+	// On Windows, FindProcess always succeeds, so we need to actually test it
+	// Send signal 0 to test if process exists (works on Unix-like systems)
+	err = process.Signal(syscall.Signal(0))
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
+// Release releases the lock when the application is shutting down
+func (si *SingleInstance) Release() {
+	if si.lockFile != nil {
+		si.lockFile.Close()
+		si.lockFile = nil
+	}
+	
+	// Remove the lock file
+	if si.lockPath != "" {
+		os.Remove(si.lockPath)
+	}
+}
+
+// GetRunningInstanceInfo returns information about any running instance
+func (si *SingleInstance) GetRunningInstanceInfo() (bool, int, error) {
+	data, err := os.ReadFile(si.lockPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, 0, nil
+		}
+		return false, 0, err
+	}
+
+	pidStr := string(data)
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return false, 0, fmt.Errorf("invalid PID in lock file: %s", pidStr)
+	}
+
+	isRunning := si.isProcessRunning(pid)
+	return isRunning, pid, nil
+}

--- a/utils.go
+++ b/utils.go
@@ -14,6 +14,10 @@ import (
 	mp3 "github.com/hajimehoshi/go-mp3"
 )
 
+// External reference to global single instance for cleanup
+// This is set in main.go and used for cleanup in SafeExit
+var globalSingleInstance *SingleInstance
+
 // NotificationManager handles system notifications with throttling
 type NotificationManager struct {
 	enabled           bool
@@ -268,6 +272,12 @@ func SafeExit(code int, message string, notificationManager *NotificationManager
 			notificationManager.NotifyError(message)
 		}
 	}
+	
+	// Clean up single instance lock if it exists
+	if globalSingleInstance != nil {
+		globalSingleInstance.Release()
+	}
+	
 	os.Exit(code)
 }
 // RestartManager handles application self-restart functionality


### PR DESCRIPTION
Introduces SingleInstance management to prevent multiple instances of the NFC UID Reader from running simultaneously. Adds signal handling for graceful shutdown and lock cleanup. Updates main.go and utils.go to integrate single instance logic and cleanup on exit. Adds singleinstance.go implementation.